### PR TITLE
Added Delete Cluster Functionality

### DIFF
--- a/kops/kops.go
+++ b/kops/kops.go
@@ -1,22 +1,23 @@
 package kops
 
 import (
+	"encoding/json"
 	"fmt"
-	clusteroperatorv1alpha1 "github.com/seizadi/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
-	"github.com/seizadi/cluster-operator/utils"
 	"strconv"
 	"strings"
-	"encoding/json"
+
+	clusteroperatorv1alpha1 "github.com/seizadi/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	"github.com/seizadi/cluster-operator/utils"
 )
 
 func CreateCluster(cluster clusteroperatorv1alpha1.KopsConfig) (string, error) {
-	
+
 	kopsCmd := "/usr/local/bin/" +
 		"kops create cluster" +
 		// FIXME - Should have
 		" --ssh-public-key=kops.pub" +
 		" --state=" + cluster.StateStore +
-		" --vpc="  + cluster.Vpc +
+		" --vpc=" + cluster.Vpc +
 		" --node-count=" + strconv.Itoa(cluster.WorkerCount) +
 		" --master-size=" + cluster.MasterEc2 +
 		" --node-size=" + cluster.WorkerEc2 +
@@ -29,14 +30,29 @@ func CreateCluster(cluster clusteroperatorv1alpha1.KopsConfig) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
+	return string(out.Bytes()), nil
+}
+
+func DeleteCluster(cluster clusteroperatorv1alpha1.KopsConfig) (string, error) {
+
+	kopsCmd := "/usr/local/bin/" +
+		"kops delete cluster --name=" + cluster.Name +
+		" --state=" + cluster.StateStore
+
+	out, err := utils.RunCmd(kopsCmd)
+	fmt.Print("\n" + string(out.Bytes()) + "\n")
+	if err != nil {
+		return "", err
+	}
+
 	return string(out.Bytes()), nil
 }
 
 func ValidateCluster(cluster clusteroperatorv1alpha1.KopsConfig) (clusteroperatorv1alpha1.KopsStatus, error) {
-	
-	status := clusteroperatorv1alpha1.KopsStatus {}
-	
+
+	status := clusteroperatorv1alpha1.KopsStatus{}
+
 	kopsCmd := "/usr/local/bin/" +
 		"kops validate cluster" +
 		" --state=" + cluster.StateStore +
@@ -45,12 +61,12 @@ func ValidateCluster(cluster clusteroperatorv1alpha1.KopsConfig) (clusteroperato
 	if err != nil {
 		return status, err
 	}
-	
+
 	json.Unmarshal(out.Bytes(), &status)
 	if err != nil {
 		return status, err
 	}
-	
+
 	fmt.Println("Kops Response: ", string(out.Bytes()))
 	return status, nil
 }

--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -2,15 +2,18 @@ package cluster
 
 import (
 	"context"
-	
-	clusteroperatorv1alpha1 "github.com/seizadi/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	"fmt"
+
 	"github.com/seizadi/cluster-operator/kops"
+	clusteroperatorv1alpha1 "github.com/seizadi/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+
 	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+
 	//"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -79,10 +82,16 @@ type ReconcileCluster struct {
 func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Cluster")
-
 	// Fetch the Cluster instance
 	instance := &clusteroperatorv1alpha1.Cluster{}
+	fmt.Print("modify get \n")
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+
+	//Finalizer name
+	clusterFinalizer := "cluster.finalizer.go"
+	fmt.Print("\n\n")
+	fmt.Print(instance.Status)
+	fmt.Print("\n\n")
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -93,84 +102,141 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	
-	// If no phase set default to pending for the initial phase
-	if instance.Status.Phase == "" {
-		instance.Status.Phase = clusteroperatorv1alpha1.ClusterPending
+
+	//The cluster is not waiting for deletion, so handle it normally
+	if instance.ObjectMeta.DeletionTimestamp.IsZero() {
+		fmt.Print("im in the normal \n")
+		// If no phase set default to pending for the initial phase
+		if instance.Status.Phase == "" {
+			fmt.Print("modify 1 \n")
+			instance.Status.Phase = clusteroperatorv1alpha1.ClusterPending
+		}
+
+		// Add the finalizer and update the object
+		if !contains(instance.ObjectMeta.Finalizers, clusterFinalizer) {
+			fmt.Print("modify 2 \n")
+			instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, clusterFinalizer)
+		}
+
+		// Run State Machine
+		// PENDING -> SETUP -> DONE
+		switch instance.Status.Phase {
+		case clusteroperatorv1alpha1.ClusterPending:
+			reqLogger.Info("Phase: PENDING")
+			_, err := kops.CreateCluster(GetKopsConfig(instance.Spec.Name))
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			reqLogger.Info("Cluster Created")
+			fmt.Print("modify 3 \n")
+			instance.Status.Phase = clusteroperatorv1alpha1.ClusterSetup
+		case clusteroperatorv1alpha1.ClusterSetup:
+			reqLogger.Info("Phase: SETUP")
+			status, err := kops.ValidateCluster(GetKopsConfig(instance.Spec.Name))
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			fmt.Print("modify 4 \n")
+			instance.Status.KopsStatus = clusteroperatorv1alpha1.KopsStatus{}
+			if len(status.Failures) > 0 {
+				fmt.Print("modify 5 \n")
+				instance.Status.KopsStatus.Failures = status.Failures
+				reqLogger.Info("Cluster Not Ready")
+			} else if len(status.Nodes) > 0 {
+				fmt.Print("modify 6 \n")
+				instance.Status.KopsStatus.Nodes = status.Nodes
+				reqLogger.Info("Cluster Created")
+				fmt.Print("modify 7 \n")
+				instance.Status.Phase = clusteroperatorv1alpha1.ClusterDone
+			} else {
+				// FIXME - If we get this state try validate again!!!
+				reqLogger.Info("Validate Returned Unexpected Result")
+			}
+		case clusteroperatorv1alpha1.ClusterDone:
+			reqLogger.Info("Phase: DONE")
+			return reconcile.Result{}, nil
+		default:
+			reqLogger.Info("NOP")
+			return reconcile.Result{}, nil
+		}
+
+		// Update the Cluster instance, setting the status to the respective phase:
+		fmt.Print("update 1 \n")
+		if err := r.client.Status().Update(context.TODO(), instance); err != nil {
+			return reconcile.Result{}, err
+		}
+		fmt.Print("update 2 \n")
+		if err := r.client.Update(context.TODO(), instance); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		if instance.Status.Phase == clusteroperatorv1alpha1.ClusterSetup {
+			// TODO - Set to time.Duration depending on back-off behavior
+			//return reconcile.Result{RequeueAfter: time.Minute}, nil
+			return reconcile.Result{Requeue: true}, nil
+		}
+
+		// Don't requeue. We should get called to reconcile when the CR changes.
+		return reconcile.Result{}, nil
+
+	} else if contains(instance.ObjectMeta.Finalizers, clusterFinalizer) {
+		// our finalizer is present, so delete cluster first
+		_, err := kops.DeleteCluster(GetKopsConfig(instance.Spec.Name))
+		reqLogger.Info("Cluster Deleted")
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// remove our finalizer from the list and update it.
+		fmt.Print("modify 8 \n")
+		instance.ObjectMeta.Finalizers = remove(instance.ObjectMeta.Finalizers, clusterFinalizer)
+		fmt.Print("update 3 \n")
+		if err := r.client.Update(context.TODO(), instance); err != nil {
+			return reconcile.Result{}, err
+		}
+
 	}
-	
-	
+	// Stop reconciliation as the item is being deleted
+	return reconcile.Result{}, nil
+
 	// Set Cluster instance as the owner and controller for AWS VPC Resource
 	// if err := controllerutil.SetControllerReference(instance, vpc, r.scheme); err != nil {
 	//	return reconcile.Result{}, err
 	//}
-	
-	// Run State Machine
-	// PENDING -> SETUP -> DONE
-	switch instance.Status.Phase {
-	case clusteroperatorv1alpha1.ClusterPending:
-		reqLogger.Info("Phase: PENDING")
-		result, err := kops.CreateCluster(GetKopsConfig(instance.Spec.Name))
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		reqLogger.Info("Cluster Created", result)
-		instance.Status.Phase = clusteroperatorv1alpha1.ClusterSetup
-	case clusteroperatorv1alpha1.ClusterSetup:
-		reqLogger.Info("Phase: SETUP")
-		status, err := kops.ValidateCluster(GetKopsConfig(instance.Spec.Name))
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		
-		instance.Status.KopsStatus = clusteroperatorv1alpha1.KopsStatus {}
-		if len(status.Failures) > 0 {
-			instance.Status.KopsStatus.Failures = status.Failures
-			reqLogger.Info("Cluster Not Ready")
-		} else if len(status.Nodes) > 0 {
-			instance.Status.KopsStatus.Nodes = status.Nodes
-			reqLogger.Info("Cluster Created")
-			instance.Status.Phase = clusteroperatorv1alpha1.ClusterDone
-		} else {
-			// FIXME - If we get this state try validate again!!!
-			reqLogger.Info("Validate Returned Unexpected Result")
-		}
-	case clusteroperatorv1alpha1.ClusterDone:
-		reqLogger.Info("Phase: DONE")
-		return reconcile.Result{}, nil
-	default:
-		reqLogger.Info("NOP")
-		return reconcile.Result{}, nil
-	}
-	
-	// Update the Cluster instance, setting the status to the respective phase:
-	err = r.client.Status().Update(context.TODO(), instance)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	
-	if instance.Status.Phase == clusteroperatorv1alpha1.ClusterSetup {
-		// TODO - Set to time.Duration depending on back-off behavior
-		//return reconcile.Result{RequeueAfter: time.Minute}, nil
-		return reconcile.Result{Requeue: true}, nil
-	}
-	
-	// Don't requeue. We should get called to reconcile when the CR changes.
-	return reconcile.Result{}, nil
+
 }
 
 // Get Kops Config Object
 func GetKopsConfig(name string) clusteroperatorv1alpha1.KopsConfig {
 	// Define a new Kops Cluster Config object
 	return clusteroperatorv1alpha1.KopsConfig{
-		Name: name + ".soheil.belamaric.com",
+		Name:        name + ".soheil.belamaric.com",
 		MasterCount: 1,
-		MasterEc2: "t2.micro",
+		MasterEc2:   "t2.micro",
 		WorkerCount: 2,
-		WorkerEc2: "t2.micro",
-		StateStore: "s3://kops.state.seizadi.infoblox.com",
-		Vpc: "vpc-0a75b33895655b46a",
-		Zones: [] string {"us-east-2a", "us-east-2b"},
+		WorkerEc2:   "t2.micro",
+		StateStore:  "s3://kops.state.seizadi.infoblox.com",
+		Vpc:         "vpc-0a75b33895655b46a",
+		Zones:       []string{"us-east-2a", "us-east-2b"},
 	}
 }
 
+// Helper functions to check and remove string from a slice of strings.
+func contains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func remove(slice []string, s string) (result []string) {
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}


### PR DESCRIPTION
This new code allows the deletion of the the cluster CR to propagate to the deletion of the actual Kops cluster. This is done by implementing a finalizer on the cluster CR. It is added to the CR on creation. The cluster is checked to see if it has a deletion timestamp; if it does, it will delete the cluster, then delete the finalizer which allows the CR to delete completely. If it does not have the timestamp, it will carry on as usual. There are also some formatting changes stuck in there.

An error will be thrown if the resource is deleted while it is going through the reconcile function since the deletion time stamp was updated while the function is trying to update the status. If that is the case, the cluster is added to the queue and tried again. Is this the expected behavior we want that error to show or should it be handled differently?